### PR TITLE
ci: bump giantswarm/architect orb to 8.2.2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 version: 2.1
 orbs:
-  architect: giantswarm/architect@8.1.0
+  architect: giantswarm/architect@8.2.2
 
 workflows:
   package-and-push-chart-on-tag:


### PR DESCRIPTION
Bumps `giantswarm/architect` from `8.1.0` to `8.2.2`. v8.2.x enables Sigstore signing, SLSA provenance, and SBOM by default. v8.2.2 fixes the missing cosign binary in the app-build-suite image.

Closes #35
Tracked under: giantswarm/giantswarm#36627

Made with [Cursor](https://cursor.com)